### PR TITLE
fix: restore ads.txt for Astro migration

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-5013570089563608, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Restored ads.txt from legacy_gatsby/static to public/ directory for Astro compatibility.