### PR TITLE
fix: unregister legacy Gatsby service worker to resolve white screen

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,11 @@
+self.addEventListener('install', (e) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (e) => {
+  self.registration.unregister()
+    .then(() => self.clients.matchAll())
+    .then((clients) => {
+      clients.forEach((client) => client.navigate(client.url));
+    });
+});

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -53,6 +53,17 @@ const siteTitle = title === "Dotorimook's Blog" ? title : `${title} | Dotorimook
 
         <!-- Google AdSense -->
         <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5013570089563608" crossorigin="anonymous"></script>
+
+        <!-- Service Worker Unregistration (Fix for Gatsby -> Astro migration) -->
+        <script is:inline>
+            if ('serviceWorker' in navigator) {
+                navigator.serviceWorker.getRegistrations().then(function(registrations) {
+                    for(let registration of registrations) {
+                        registration.unregister();
+                    }
+                });
+            }
+        </script>
 	</head>
 	<body>
 		<slot />


### PR DESCRIPTION
## Summary
This PR fixes the "page resources for / not found" error and subsequent white screen issue caused by a stale Service Worker from the previous Gatsby site.

## Problem
- After migrating from Gatsby to Astro, users who previously visited the site have a Gatsby-generated Service Worker (`sw.js` or via `gatsby-plugin-offline`) installed in their browser.
- This old Service Worker tries to fetch resources that no longer exist on the new Astro deployment, leading to 404 errors and a blank page.

## Solution
1.  **Overwrite `sw.js`**: Created a new `public/sw.js` that immediately unregisters itself and forces a page reload.
2.  **Force Unregister in `Layout.astro`**: Added an inline script to the `<head>` of the main layout to programmatically unregister any active Service Workers.

## Testing
- Verify that visiting the site with an old Service Worker no longer results in a white screen.
- The browser should automatically reload once the Service Worker is unregistered.