### PR TITLE
fix: add redirect rule for broken URL with space

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,10 @@ import sitemap from '@astrojs/sitemap';
 // https://astro.build/config
 export default defineConfig({
   site: 'https://dotorimook.github.io',
+  redirects: {
+    '/post/2021-05-02-check-intel-mac-app copy/': '/post/2021-05-02-check-intel-mac-app-copy/',
+    '/post/2021-05-02-check-intel-mac-app%20copy/': '/post/2021-05-02-check-intel-mac-app-copy/',
+  },
   integrations: [
     react(),
     sitemap()


### PR DESCRIPTION
## Summary

Google Search Console에서 보고된 "깨진 URL (404)" 문제를 해결하기 위해 리다이렉트 규칙을 추가했습니다.

## Issue

- **Old URL**: `/post/2021-05-02-check-intel-mac-app%20copy/` (Gatsby 시절, 공백 포함)
- **New URL**: `/post/2021-05-02-check-intel-mac-app-copy/` (Astro 마이그레이션 후, 하이픈 변경)
- **증상**: 구글 검색 결과에서 구 주소로 접속 시 404 에러 발생

## Solution

`astro.config.mjs`에 301 리다이렉트 규칙을 추가했습니다.
안전성을 위해 **디코딩된 경로(공백 포함)**와 **인코딩된 경로(%20 포함)** 두 가지 경우를 모두 처리하도록 설정했습니다.

```javascript
redirects: {
  '/post/2021-05-02-check-intel-mac-app copy/': '/post/2021-05-02-check-intel-mac-app-copy/',
  '/post/2021-05-02-check-intel-mac-app%20copy/': '/post/2021-05-02-check-intel-mac-app-copy/',
}
```

## Verification

- `npm run build` 성공 확인
- 설정 파일 문법 확인