### PR TITLE
fix: add redirect for sitemap.xml to sitemap-index.xml

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ export default defineConfig({
   redirects: {
     '/post/2021-05-02-check-intel-mac-app copy/': '/post/2021-05-02-check-intel-mac-app-copy/',
     '/post/2021-05-02-check-intel-mac-app%20copy/': '/post/2021-05-02-check-intel-mac-app-copy/',
+    '/sitemap.xml': '/sitemap-index.xml',
   },
   integrations: [
     react(),


### PR DESCRIPTION
## Summary

`sitemap.xml`을 찾는 도구 및 사용자들을 위해 기본 생성되는 `sitemap-index.xml`로 리다이렉트되도록 설정했습니다.

## Issue

- Astro v5는 기본적으로 `sitemap-index.xml`을 생성합니다.
- 많은 SEO 도구나 봇은 여전히 `sitemap.xml`을 먼저 찾습니다.
- 이로 인해 404 에러가 발생할 수 있습니다.

## Solution

`astro.config.mjs`에 301 리다이렉트 규칙 추가:
```javascript
redirects: {
  '/sitemap.xml': '/sitemap-index.xml',
  // ...
}
```

## Verification

- `npm run build` 성공 확인
- 설정 파일 문법 확인